### PR TITLE
feat(rayzee): unified DOM mount via options.container

### DIFF
--- a/app/src/components/layout/Viewports/Viewport3D.jsx
+++ b/app/src/components/layout/Viewports/Viewport3D.jsx
@@ -183,18 +183,12 @@ const Viewport3D = forwardRef( ( { viewportMode = "preview" }, ref ) => {
 			const initApp = async () => {
 
 				const app = new PathTracerApp( canvasRef.current, {
+					container: containerRef.current,
 					statsContainer: viewportRef.current
 				} );
 				appRef.current = app;
 				setLoading( { isLoading: true, title: "Starting", status: "Initializing WebGPU...", progress: 30 } );
 				await app.init();
-
-				// Mount HUD overlay canvas on top of the WebGPU canvas
-				if ( app.overlayManager ) {
-
-					containerRef.current.appendChild( app.overlayManager.getHUDCanvas() );
-
-				}
 
 				// Register with appProxy so getApp() works globally
 				setApp( app );

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,7 +8,7 @@
 - [ ] scrutenize for which all stages are needed as default
 - [ ] dispose, reset, etc life cycle for rayzee engine. 
 - [ ] optimized 4k hdr enviroments
-- [ ] single DOM parant for all mountings, tiles, denoisers etc
+- [x] single DOM parant for all mountings, tiles, denoisers etc
   
 ### Known
 
@@ -116,7 +116,7 @@
 - [x] Ranged GPU upload (addUpdateRange) for partial buffer updates
 - [x] TLAS in-place refit instead of full SAH rebuild on transform
 - [ ] Object-space triangles + instance transform buffer for true instancing
-- [ ] GPU compute refit via compute shader (blocked on Three.js read-write storage buffers)
+- [ ] GPU compute refit via compute shader (level-by-level dispatch with barriers; replaces worker + SharedArrayBuffer path)
 - [ ] Background BLAS rebuild after refit when SAH quality degrades
 - [ ] Compact Wide BVH (CWBVH) — 4/8-way branching for GPU traversal
 

--- a/rayzee/README.md
+++ b/rayzee/README.md
@@ -230,7 +230,10 @@ const engine = new PathTracerApp(canvas, options?)
 | `canvas` | `HTMLCanvasElement` | Rendering target |
 | `options.autoResize` | `boolean` | Auto-resize on window resize (default: `true`) |
 | `options.showStats` | `boolean` | Show the performance stats panel (default: `true`) |
-| `options.statsContainer` | `HTMLElement` | DOM element to append the stats panel to (defaults to `document.body`) |
+| `options.container` | `HTMLElement` | Single DOM parent the engine mounts auxiliary elements into — HUD overlay (tile borders, helpers), denoiser canvas, and stats panel. Defaults to `canvas.parentNode`. |
+| `options.statsContainer` | `HTMLElement` | Override mount target for the stats panel only. Defaults to `options.container`. |
+
+The engine creates and mounts everything it needs (denoiser canvas, tile/HUD overlay, stats) into a single parent on `init()`
 
 #### Lifecycle
 

--- a/rayzee/src/PathTracerApp.js
+++ b/rayzee/src/PathTracerApp.js
@@ -65,7 +65,10 @@ export class PathTracerApp extends EventDispatcher {
 	 * @param {Object} [options] - Engine options
 	 * @param {boolean} [options.autoResize=true] - Automatically listen for window resize events
 	 * @param {boolean} [options.showStats=true] - Show the performance stats panel
-	 * @param {HTMLElement} [options.statsContainer] - DOM element to append the stats panel to (defaults to document.body)
+	 * @param {HTMLElement} [options.container] - Single DOM parent the engine mounts all auxiliary
+	 *   elements into (HUD overlay, denoiser canvas, stats). Defaults to `canvas.parentNode`.
+	 * @param {HTMLElement} [options.statsContainer] - Override mount target for the stats panel only.
+	 *   Defaults to `options.container`.
 	 */
 	constructor( canvas, options = {} ) {
 
@@ -86,6 +89,7 @@ export class PathTracerApp extends EventDispatcher {
 		this.canvas = canvas;
 		this._autoResize = options.autoResize !== false;
 		this._showStats = options.showStats !== false;
+		this._container = options.container || null;
 		this._statsContainer = options.statsContainer || null;
 
 		// ── Settings (single source of truth for all render parameters) ──
@@ -1550,7 +1554,7 @@ export class PathTracerApp extends EventDispatcher {
 
 	_initStats() {
 
-		const container = this._statsContainer || this.canvas.parentElement || document.body;
+		const container = this._statsContainer || this._container || this.canvas.parentElement || document.body;
 		this._stats = createStats( this.renderer, container );
 
 	}
@@ -1591,6 +1595,9 @@ export class PathTracerApp extends EventDispatcher {
 			renderWidth: this.denoisingManager?._lastRenderWidth || this.canvas.clientWidth || 1,
 			renderHeight: this.denoisingManager?._lastRenderHeight || this.canvas.clientHeight || 1,
 		} );
+
+		this._container = this._container || this.canvas.parentNode || null;
+		this.overlayManager.mount( this._container );
 
 	}
 

--- a/rayzee/src/managers/OverlayManager.js
+++ b/rayzee/src/managers/OverlayManager.js
@@ -57,13 +57,25 @@ export class OverlayManager {
 	}
 
 	/**
-	 * Returns the HUD canvas element. The app should mount this on top of the
-	 * WebGPU canvas (absolute-positioned, pointer-events: none).
+	 * Returns the HUD canvas element. Normally mounted automatically by
+	 * {@link PathTracerApp}; exposed for advanced clients that mount it manually.
 	 * @returns {HTMLCanvasElement}
 	 */
 	getHUDCanvas() {
 
 		return this._hudCanvas;
+
+	}
+
+	/**
+	 * Mounts the HUD canvas into the given container. Idempotent — safe to call
+	 * multiple times; re-mounts only when the parent differs.
+	 * @param {HTMLElement} container
+	 */
+	mount( container ) {
+
+		if ( ! container || this._hudCanvas.parentElement === container ) return;
+		container.appendChild( this._hudCanvas );
 
 	}
 


### PR DESCRIPTION
Add an `options.container` parameter to PathTracerApp so the engine auto-mounts the HUD overlay canvas (tile borders, helpers) alongside the denoiser canvas and stats panel into a single parent. Clients no longer need to manually appendChild the HUD canvas; falls back to canvas.parentNode when no container is provided.

- OverlayManager: add idempotent mount(container)
- PathTracerApp: resolve container in init(); statsContainer falls through to options.container
- App: pass containerRef as options.container; drop the manual HUD mount

<!-- Thanks for contributing to Rayzee! Please fill out the sections below. -->

## Description

<!-- What does this PR do? Why is it needed? Link any related issues. -->

Closes #

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Performance improvement (`perf:`)
- [ ] Refactor — no behavior change (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Build / CI / Tooling (`build:` / `ci:` / `chore:`)

## Testing

<!-- How did you verify the change? -->

- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] Manually tested in browser (Chrome/Edge with WebGPU)
- [ ] Verified no performance regression
- [ ] Cross-browser checked (if UI/rendering change)

## Screenshots / Videos

<!-- For UI or rendering changes, include before/after captures. -->

## Checklist

- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit--pr-conventions)
- [ ] Code follows the style guide in `CONTRIBUTING.md`
- [ ] Self-reviewed the diff
- [ ] Updated documentation where relevant (README, CLAUDE.md, docs/)
- [ ] No leftover debug logs or commented-out code
